### PR TITLE
Bump cluster-aws to v0.51.0 and adapt to renamed values, bump default-apps-aws to v0.40.0

### DIFF
--- a/helm/outgoing-proxy-stack/templates/crs.yaml
+++ b/helm/outgoing-proxy-stack/templates/crs.yaml
@@ -1,48 +1,49 @@
 apiVersion: v1
 data:
   values: |
-    baseDomain: {{ .Values.cluster.baseDomain }}
-    providerSpecific:
-      region: {{ .Values.aws.region }}
-    connectivity:
-      bastion:
-        enabled: false
-      availabilityZoneUsageLimit: 3
-      dns:
-        mode: {{ .Values.cluster.dnsMode }}
-      subnets:
-        - cidrBlocks:
-            - cidr: 10.255.0.0/20
-              availabilityZone: a
-            - cidr: 10.255.16.0/20
-              availabilityZone: b
-            - cidr: 10.255.32.0/20
-              availabilityZone: c
-          isPublic: true
-        - cidrBlocks:
-            - cidr: 10.255.64.0/18
-              availabilityZone: a
-            - cidr: 10.255.128.0/18
-              availabilityZone: b
-            - cidr: 10.255.192.0/18
-              availabilityZone: c
-          isPublic: false
-      topology:
-        mode: GiantSwarmManaged
-      network:
-        vpcCidr: {{ .Values.cluster.vpcCIDR }}
-      proxy:
-        enabled: false
-    metadata:
-      name: {{ .Values.cluster.name }}
-      organization: {{ .Values.cluster.organization }}
-    nodePools:
-      def00:
-        instanceType: r6i.xlarge
-        maxSize: 2
-        minSize: 2
-        availabilityZones: {{ .Values.aws.azs | toYaml | nindent 8 }}
-        rootVolumeSizeGB: 100
+    global:
+      providerSpecific:
+        region: {{ .Values.aws.region }}
+      connectivity:
+        baseDomain: {{ .Values.cluster.baseDomain }}
+        bastion:
+          enabled: false
+        availabilityZoneUsageLimit: 3
+        dns:
+          mode: {{ .Values.cluster.dnsMode }}
+        subnets:
+          - cidrBlocks:
+              - cidr: 10.255.0.0/20
+                availabilityZone: a
+              - cidr: 10.255.16.0/20
+                availabilityZone: b
+              - cidr: 10.255.32.0/20
+                availabilityZone: c
+            isPublic: true
+          - cidrBlocks:
+              - cidr: 10.255.64.0/18
+                availabilityZone: a
+              - cidr: 10.255.128.0/18
+                availabilityZone: b
+              - cidr: 10.255.192.0/18
+                availabilityZone: c
+            isPublic: false
+        topology:
+          mode: GiantSwarmManaged
+        network:
+          vpcCidr: {{ .Values.cluster.vpcCIDR }}
+        proxy:
+          enabled: false
+      metadata:
+        name: {{ .Values.cluster.name }}
+        organization: {{ .Values.cluster.organization }}
+      nodePools:
+        def00:
+          instanceType: r6i.xlarge
+          maxSize: 2
+          minSize: 2
+          availabilityZones: {{- .Values.aws.azs | toYaml | nindent 10 }}
+          rootVolumeSizeGB: 100
 kind: ConfigMap
 metadata:
   labels:

--- a/helm/outgoing-proxy-stack/values.yaml
+++ b/helm/outgoing-proxy-stack/values.yaml
@@ -13,7 +13,7 @@ apps:
   cilliumApiEndpoint: ""
   # used by renovate
   # repo: giantswarm/default-apps-aws
-  version: "0.30.0"
+  version: 0.40.0
 
 cluster:
   baseDomain: ""
@@ -23,7 +23,7 @@ cluster:
   organization: giantswarm
   # used by renovate
   # repo: giantswarm/cluster-aws
-  version: "0.36.2"
+  version: 0.51.0
 
 proxy:
   # used by renovate


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2870 and https://github.com/giantswarm/roadmap/issues/2954