### PR TITLE
Update `squid-proxy` to `v0.6.0`

### DIFF
--- a/helm/outgoing-proxy-stack/values.yaml
+++ b/helm/outgoing-proxy-stack/values.yaml
@@ -28,6 +28,6 @@ cluster:
 proxy:
   # used by renovate
   # repo: giantswarm/squid-proxy-app
-  version: 0.5.5
+  version: 0.6.0
   image: giantswarm/squid
   tag: 5.6-22.10_beta-giantswarm_gs1


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30612

Release [squid-proxy v0.6.0](https://github.com/giantswarm/squid-proxy-app/pull/59) to allow `.slack.com` domain.