### PR TITLE
Upgrade default-apps-aws and cluster-aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+In preparation to upgrade `cluster-aws` to [`v0.76.0`](https://github.com/giantswarm/cluster-aws/releases/tag/v0.76.0):
+
+- Upgrade `default-apps-aws` to `0.52.0`
+- Upgrade `cluster-aws` to `0.75.0`
+- Add `apps.deleteOptions.moveAppsHelmOwnershipToClusterAws` value (defaults to `false`) to be able to migrate default apps to `cluster-aws`. Set this to `true` before upgrading to the next version of this app.
+
 ## [0.12.0] - 2024-05-06
 
 ### Changed

--- a/helm/outgoing-proxy-stack/templates/crs.yaml
+++ b/helm/outgoing-proxy-stack/templates/crs.yaml
@@ -85,6 +85,8 @@ data:
   values: |
     clusterName: {{ .Values.cluster.name }}
     organization: {{ .Values.cluster.organization }}
+    deleteOptions:
+      moveAppsHelmOwnershipToClusterAws: {{ .Values.apps.deleteOptions.moveAppsHelmOwnershipToClusterAws }}
     {{- if ne .Values.apps.cilliumApiEndpoint "" }}
     userConfig:
       cilium:

--- a/helm/outgoing-proxy-stack/values.schema.json
+++ b/helm/outgoing-proxy-stack/values.schema.json
@@ -8,6 +8,14 @@
                 "cilliumApiEndpoint": {
                     "type": "string"
                 },
+                "deleteOptions": {
+                    "type": "object",
+                    "properties": {
+                        "moveAppsHelmOwnershipToClusterAws": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "version": {
                     "type": "string"
                 }

--- a/helm/outgoing-proxy-stack/values.yaml
+++ b/helm/outgoing-proxy-stack/values.yaml
@@ -13,7 +13,9 @@ apps:
   cilliumApiEndpoint: ""
   # used by renovate
   # repo: giantswarm/default-apps-aws
-  version: 0.51.0
+  version: 0.52.0
+  deleteOptions:
+    moveAppsHelmOwnershipToClusterAws: false
 
 cluster:
   baseDomain: ""
@@ -23,7 +25,7 @@ cluster:
   organization: giantswarm
   # used by renovate
   # repo: giantswarm/cluster-aws
-  version: 0.68.0
+  version: 0.75.0
 
 proxy:
   # used by renovate


### PR DESCRIPTION
This upgrades both apps to the latest versions before the default apps merge into cluster-aws (< 0.76.0). This intermediate step is needed for subsequent upgrades.

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->